### PR TITLE
Handle errors; await for finished promises

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "sanity-translations-tab": "^1.1.43"
       },
       "devDependencies": {
+        "@sanity/client": "^2.22.3",
         "@sanity/types": "^2.22.3",
         "@size-limit/preset-small-lib": "^4.7.0",
         "husky": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     }
   ],
   "devDependencies": {
+    "@sanity/client": "^2.22.3",
     "@sanity/types": "^2.22.3",
     "@size-limit/preset-small-lib": "^4.7.0",
     "husky": "^4.3.0",

--- a/src/adapter/getTranslation.ts
+++ b/src/adapter/getTranslation.ts
@@ -13,7 +13,16 @@ export const getTranslation = async (
     headers: getHeaders(url, accessToken),
   })
     .then(res => res.json())
-    .then(res => res.body)
+    .then(res => {
+      if (res.body) {
+        return res.body
+      } else if (res.response.errors) {
+        const errMsg =
+          res.response.errors[0]?.message ||
+          'Error retrieving translation from Smartling'
+        throw new Error(errMsg)
+      }
+    })
 
   return translatedHTML
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -17,9 +17,6 @@ export const findLatestDraft = (documentId: string, ignoreI18n = true) => {
       (docs: SanityDocument[]) =>
         docs.find(doc => doc._id.includes('draft')) ?? docs[0]
     )
-    .catch(err => {
-      throw err
-    })
 }
 
 //revision fetch
@@ -33,9 +30,6 @@ export const findDocumentAtRevision = async (
   let revisionDoc = await fetch(url, { credentials: 'include' })
     .then(req => req.json())
     .then(req => req.documents[0])
-    .catch(err => {
-      throw err
-    })
 
   /* endpoint will silently give you incorrect doc
    * if you don't request draft and the rev belongs to a draft, so check
@@ -46,9 +40,6 @@ export const findDocumentAtRevision = async (
     revisionDoc = await fetch(url, { credentials: 'include' })
       .then(req => req.json())
       .then(req => req.documents[0])
-      .catch(err => {
-        throw err
-      })
   }
 
   return revisionDoc
@@ -60,55 +51,46 @@ export const documentLevelPatch = async (
   translatedFields: SanityDocument,
   localeId: string
 ) => {
-  try {
-    let baseDoc: SanityDocument
-    if (translatedFields._rev) {
-      baseDoc = await findDocumentAtRevision(documentId, translatedFields._rev)
-    } else {
-      baseDoc = await findLatestDraft(documentId)
-    }
+  let baseDoc: SanityDocument
+  if (translatedFields._rev) {
+    baseDoc = await findDocumentAtRevision(documentId, translatedFields._rev)
+  } else {
+    baseDoc = await findLatestDraft(documentId)
+  }
 
-    const merged = BaseDocumentMerger.documentLevelMerge(
-      translatedFields,
-      baseDoc
-    )
-    const targetId = `i18n.${documentId}.${localeId}`
-    const i18nDoc = await findLatestDraft(targetId, false)
+  const merged = BaseDocumentMerger.documentLevelMerge(
+    translatedFields,
+    baseDoc
+  )
+  const targetId = `i18n.${documentId}.${localeId}`
+  const i18nDoc = await findLatestDraft(targetId, false)
 
-    if (i18nDoc) {
-      const cleanedMerge: Record<string, any> = {}
-      //don't overwrite any existing values on the i18n doc
-      Object.entries(merged).forEach(([key, value]) => {
-        if (
-          Object.keys(translatedFields).includes(key) &&
-          !['_id', '_rev', '_updatedAt'].includes(key)
-        ) {
-          cleanedMerge[key] = value
-        }
-      })
-
-      await client
-        .transaction()
-        //@ts-ignore
-        .patch(i18nDoc._id, p => p.set(cleanedMerge))
-        .commit()
-        .catch(err => {
-          throw err
-        })
-    } else {
-      merged._id = `drafts.${targetId}`
-      //account for legacy implementations of i18n plugin lang
-      if (baseDoc._lang) {
-        merged._lang = localeId
-      } else if (baseDoc.__i18n_lang) {
-        merged.__i18n_lang = localeId
+  if (i18nDoc) {
+    const cleanedMerge: Record<string, any> = {}
+    //don't overwrite any existing values on the i18n doc
+    Object.entries(merged).forEach(([key, value]) => {
+      if (
+        Object.keys(translatedFields).includes(key) &&
+        !['_id', '_rev', '_updatedAt'].includes(key)
+      ) {
+        cleanedMerge[key] = value
       }
-      client.create(merged).catch(err => {
-        throw err
-      })
+    })
+
+    await client
+      .transaction()
+      //@ts-ignore
+      .patch(i18nDoc._id, p => p.set(cleanedMerge))
+      .commit()
+  } else {
+    merged._id = `drafts.${targetId}`
+    //account for legacy implementations of i18n plugin lang
+    if (baseDoc._lang) {
+      merged._lang = localeId
+    } else if (baseDoc.__i18n_lang) {
+      merged.__i18n_lang = localeId
     }
-  } catch (err) {
-    throw err
+    client.create(merged)
   }
 }
 
@@ -118,29 +100,22 @@ export const fieldLevelPatch = async (
   translatedFields: SanityDocument,
   localeId: string
 ) => {
-  try {
-    let baseDoc: SanityDocument
-    if (translatedFields._rev) {
-      baseDoc = await findDocumentAtRevision(documentId, translatedFields._rev)
-    } else {
-      baseDoc = await findLatestDraft(documentId)
-    }
-
-    const merged = BaseDocumentMerger.fieldLevelMerge(
-      translatedFields,
-      baseDoc,
-      localeId,
-      'en'
-    )
-
-    await client
-      .patch(baseDoc._id)
-      .set(merged)
-      .commit()
-      .catch(err => {
-        throw err
-      })
-  } catch (err) {
-    throw err
+  let baseDoc: SanityDocument
+  if (translatedFields._rev) {
+    baseDoc = await findDocumentAtRevision(documentId, translatedFields._rev)
+  } else {
+    baseDoc = await findLatestDraft(documentId)
   }
+
+  const merged = BaseDocumentMerger.fieldLevelMerge(
+    translatedFields,
+    baseDoc,
+    localeId,
+    'en'
+  )
+
+  await client
+    .patch(baseDoc._id)
+    .set(merged)
+    .commit()
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,34 +12,53 @@ import { SanityDocument } from '@sanity/types'
 
 const defaultDocumentLevelConfig = {
   exportForTranslation: async (id: string) => {
-    const doc = await findLatestDraft(id)
-    const serialized = BaseDocumentSerializer.serializeDocument(doc, 'document')
-    //needed for lookup by translation tab
-    serialized.name = id
-    return serialized
+    try {
+      const doc = await findLatestDraft(id)
+      const serialized = BaseDocumentSerializer.serializeDocument(
+        doc,
+        'document'
+      )
+      //needed for lookup by translation tab
+      serialized.name = id
+      return serialized
+    } catch (err) {
+      throw err
+    }
   },
-  importTranslation: (id: string, localeId: string, document: string) => {
-    const deserialized = BaseDocumentDeserializer.deserializeDocument(
-      document
-    ) as SanityDocument
-    documentLevelPatch(id, deserialized, localeId)
+  importTranslation: async (id: string, localeId: string, document: string) => {
+    try {
+      const deserialized = BaseDocumentDeserializer.deserializeDocument(
+        document
+      ) as SanityDocument
+      await documentLevelPatch(id, deserialized, localeId)
+    } catch (err) {
+      throw err
+    }
   },
   adapter: SmartlingAdapter,
 }
 
 const defaultFieldLevelConfig = {
   exportForTranslation: async (id: string) => {
-    const doc = await findLatestDraft(id)
-    const serialized = BaseDocumentSerializer.serializeDocument(doc, 'field')
-    //needed for lookup by translation tab
-    serialized.name = id
-    return serialized
+    try {
+      const doc = await findLatestDraft(id)
+      const serialized = BaseDocumentSerializer.serializeDocument(doc, 'field')
+      //needed for lookup by translation tab
+      serialized.name = id
+      return serialized
+    } catch (err) {
+      throw err
+    }
   },
-  importTranslation: (id: string, localeId: string, document: string) => {
-    const deserialized = BaseDocumentDeserializer.deserializeDocument(
-      document
-    ) as SanityDocument
-    fieldLevelPatch(id, deserialized, localeId)
+  importTranslation: async (id: string, localeId: string, document: string) => {
+    try {
+      const deserialized = BaseDocumentDeserializer.deserializeDocument(
+        document
+      ) as SanityDocument
+      await fieldLevelPatch(id, deserialized, localeId)
+    } catch (err) {
+      throw err
+    }
   },
   adapter: SmartlingAdapter,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,53 +12,34 @@ import { SanityDocument } from '@sanity/types'
 
 const defaultDocumentLevelConfig = {
   exportForTranslation: async (id: string) => {
-    try {
-      const doc = await findLatestDraft(id)
-      const serialized = BaseDocumentSerializer.serializeDocument(
-        doc,
-        'document'
-      )
-      //needed for lookup by translation tab
-      serialized.name = id
-      return serialized
-    } catch (err) {
-      throw err
-    }
+    const doc = await findLatestDraft(id)
+    const serialized = BaseDocumentSerializer.serializeDocument(doc, 'document')
+    //needed for lookup by translation tab
+    serialized.name = id
+    return serialized
   },
   importTranslation: async (id: string, localeId: string, document: string) => {
-    try {
-      const deserialized = BaseDocumentDeserializer.deserializeDocument(
-        document
-      ) as SanityDocument
-      await documentLevelPatch(id, deserialized, localeId)
-    } catch (err) {
-      throw err
-    }
+    const deserialized = BaseDocumentDeserializer.deserializeDocument(
+      document
+    ) as SanityDocument
+    await documentLevelPatch(id, deserialized, localeId)
   },
   adapter: SmartlingAdapter,
 }
 
 const defaultFieldLevelConfig = {
   exportForTranslation: async (id: string) => {
-    try {
-      const doc = await findLatestDraft(id)
-      const serialized = BaseDocumentSerializer.serializeDocument(doc, 'field')
-      //needed for lookup by translation tab
-      serialized.name = id
-      return serialized
-    } catch (err) {
-      throw err
-    }
+    const doc = await findLatestDraft(id)
+    const serialized = BaseDocumentSerializer.serializeDocument(doc, 'field')
+    //needed for lookup by translation tab
+    serialized.name = id
+    return serialized
   },
   importTranslation: async (id: string, localeId: string, document: string) => {
-    try {
-      const deserialized = BaseDocumentDeserializer.deserializeDocument(
-        document
-      ) as SanityDocument
-      await fieldLevelPatch(id, deserialized, localeId)
-    } catch (err) {
-      throw err
-    }
+    const deserialized = BaseDocumentDeserializer.deserializeDocument(
+      document
+    ) as SanityDocument
+    await fieldLevelPatch(id, deserialized, localeId)
   },
   adapter: SmartlingAdapter,
 }


### PR DESCRIPTION
There are lots of points of potential silent and/or unhandled errors
due to not applying await for async functions and/or not using a
`catch` for any errors thrown. If we don't add `await` or `throw`
errors, then the translation tab won't be able to tell if a the call
is actually complete or was successful, resulting in a "Success" toast
that's potentially inaccurate.

I tried manually adding in errors in all the various calls and
triggering the "Import" from the button in the translation tab and this
update (along with the parallel change to `TranslationsTab`) allowed
all of them to be caught in the `try/catch` added to `imortFile` in
TranslationsTab.

Note, however, that I didn't test the documentLevel functions because I
don't have that implemented. I copied the changes made for fieldLevel
and have no reason to believe they wouldn't work :)

Related PR: https://github.com/All-Turtles/sanity-translations-tab/pull/5

<img width="1778" alt="Screen Shot 2022-02-01 at 6 24 02 PM" src="https://user-images.githubusercontent.com/11039888/152084943-184a3244-1f69-4f9b-b076-c54912f37d03.png">

<img width="692" alt="Screen Shot 2022-02-01 at 6 24 39 PM" src="https://user-images.githubusercontent.com/11039888/152084954-10275047-9564-4703-b291-1327ff4dfc53.png">
