### PR TITLE
Remove `@sanity/client` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,17 @@
 {
   "name": "sanity-plugin-studio-smartling",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "sanity-plugin-studio-smartling",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "sanity-naive-html-serializer": "^1.3.0",
         "sanity-translations-tab": "^1.2.0"
       },
       "devDependencies": {
-        "@sanity/client": "^2.22.3",
         "@sanity/types": "^2.22.3",
         "@size-limit/preset-small-lib": "^4.7.0",
         "husky": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     }
   ],
   "devDependencies": {
-    "@sanity/client": "^2.22.3",
     "@sanity/types": "^2.22.3",
     "@size-limit/preset-small-lib": "^4.7.0",
     "husky": "^4.3.0",


### PR DESCRIPTION
Had added this as a dependency in attempt to fix error showing in VSCode
in helper.js where we import `sanityClient`, but that created different
issues when I tried to use `@sanity/client` instead of
`'part:@sanity/base/client'`, so just removing the dependency from package.